### PR TITLE
A user can exist without this property, even though the plugin is loa…

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -69,7 +69,10 @@ public class ActiveNotifier implements FineGrainedNotifier {
         if (cause != null) {
             User user = User.get(cause.getUserId());
             if (user != null) {
-                slackUsername = user.getProperty(SlackNotifier.SlackUserProperty.class).getUsername();
+                SlackNotifier.SlackUserProperty property = user.getProperty(SlackNotifier.SlackUserProperty.class);
+                if (property != null) {
+                    slackUsername = property.getUsername();
+                }
             }
         }
 


### PR DESCRIPTION
### CHANGE SUMMARY
Fixes a NPE when a cause is found, a user is found, but the user hasn't physically looked at and clicked save on their configuration page.

### CHANGE DETAILS
![plo1wvm gif](https://cloud.githubusercontent.com/assets/13439988/9363937/5897300e-465e-11e5-82a3-d1f853298008.gif)
