### PR TITLE
Double Notification Fix

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -114,6 +114,8 @@ public class ActiveNotifier implements FineGrainedNotifier {
                 MessageBuilder message = new MessageBuilder(notifier, build);
                 message.append(causeAction.getShortDescription());
                 notifyStart(build, message.appendOpenLink().toString());
+                // If we've sent a notification here, there's no need to continue and try to send another
+                return;
             }
         }
 


### PR DESCRIPTION
### CHANGE SUMMARY
Two notifications were being sent when a build was triggered by Source Code Management and a user was found.  This limits it to only the user notification if available, otherwise the trigger notification.

![tumblrmsl4j0quwg1rw9dz1o3r1400](https://cloud.githubusercontent.com/assets/13439988/9502776/1111235e-4be8-11e5-9b5b-20ef1300fa19.gif)
